### PR TITLE
Revamp UI with Apple-inspired styling

### DIFF
--- a/src/components/AddAlbumForm.tsx
+++ b/src/components/AddAlbumForm.tsx
@@ -193,7 +193,7 @@ const AddAlbumForm: React.FC<AddAlbumFormProps> = ({ onAddAlbum }) => {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
+    <div className="bg-white/80 backdrop-blur-md rounded-xl shadow p-6">
       <h2 className="text-xl font-semibold text-gray-900 mb-4">Add New Album</h2>
 
       <form onSubmit={handleSearch} className="space-y-4 mb-4">

--- a/src/components/AlbumDetailModal.tsx
+++ b/src/components/AlbumDetailModal.tsx
@@ -132,7 +132,7 @@ const AlbumDetailModal: React.FC<AlbumDetailModalProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="bg-white/90 backdrop-blur-md rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <h2 className="text-2xl font-bold text-gray-800">
@@ -164,7 +164,7 @@ const AlbumDetailModal: React.FC<AlbumDetailModalProps> = ({
             {/* Cover Art */}
             <div className="space-y-4">
               <h3 className="text-lg font-semibold text-gray-800">Cover Art</h3>
-              <div className="aspect-square bg-gray-100 rounded-lg overflow-hidden">
+              <div className="aspect-square bg-gray-50 rounded-lg overflow-hidden">
                 {getCurrentImageUrl() ? (
                   <img
                     src={getCurrentImageUrl()}
@@ -191,7 +191,7 @@ const AlbumDetailModal: React.FC<AlbumDetailModalProps> = ({
                       className={`flex-1 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
                         uploadMethod === 'url'
                           ? 'bg-blue-100 text-blue-700 border border-blue-300'
-                          : 'bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-200'
+                          : 'bg-gray-50 text-gray-600 border border-gray-300 hover:bg-gray-200'
                       }`}
                     >
                       URL
@@ -201,7 +201,7 @@ const AlbumDetailModal: React.FC<AlbumDetailModalProps> = ({
                       className={`flex-1 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
                         uploadMethod === 'file'
                           ? 'bg-blue-100 text-blue-700 border border-blue-300'
-                          : 'bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-200'
+                          : 'bg-gray-50 text-gray-600 border border-gray-300 hover:bg-gray-200'
                       }`}
                     >
                       Upload

--- a/src/components/AlbumList.tsx
+++ b/src/components/AlbumList.tsx
@@ -34,7 +34,7 @@ const AlbumList: React.FC<AlbumListProps> = ({ albums, onDeleteAlbum, onUpdateAl
 
   if (albums.length === 0) {
     return (
-      <div className="bg-white rounded-lg shadow p-8 text-center">
+      <div className="bg-white/80 backdrop-blur-md rounded-xl shadow p-8 text-center">
         <Music className="mx-auto h-12 w-12 text-gray-400 mb-4" />
         <h3 className="text-lg font-medium text-gray-900 mb-2">No albums yet</h3>
         <p className="text-gray-500">Start building your vinyl collection by adding your first album!</p>
@@ -66,7 +66,7 @@ const AlbumList: React.FC<AlbumListProps> = ({ albums, onDeleteAlbum, onUpdateAl
 
   return (
     <>
-      <div className="bg-white rounded-lg shadow">
+      <div className="bg-white/80 backdrop-blur-md rounded-xl shadow">
         <div className="px-6 py-4 border-b border-gray-200">
           <h2 className="text-xl font-semibold text-gray-900">Your Collection ({albums.length} albums)</h2>
         </div>

--- a/src/components/CSVImport.tsx
+++ b/src/components/CSVImport.tsx
@@ -208,7 +208,7 @@ const CSVImport: React.FC<CSVImportProps> = ({ onAddAlbums }) => {
   const failedCount = importResults.filter(r => !r.success).length;
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
+    <div className="bg-white/80 backdrop-blur-md rounded-xl shadow p-6">
       <h2 className="text-xl font-semibold text-gray-900 mb-4">Bulk Import from CSV</h2>
 
       <div className="mb-4">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -25,8 +25,8 @@ class ErrorBoundary extends Component<Props, State> {
   public render() {
     if (this.state.hasError) {
       return (
-        <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg shadow-lg p-8 max-w-md w-full">
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+          <div className="bg-white/80 backdrop-blur-md rounded-xl shadow-lg p-8 max-w-md w-full">
             <h1 className="text-2xl font-bold text-red-600 mb-4">Something went wrong</h1>
             <p className="text-gray-600 mb-4">
               The application encountered an error. Please check the console for more details.
@@ -34,7 +34,7 @@ class ErrorBoundary extends Component<Props, State> {
             {this.state.error && (
               <details className="text-sm text-gray-500">
                 <summary className="cursor-pointer mb-2">Error Details</summary>
-                <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto">
+                <pre className="bg-gray-50 p-2 rounded text-xs overflow-auto">
                   {this.state.error.toString()}
                 </pre>
               </details>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,7 +10,7 @@ const Navigation: React.FC = () => {
   };
 
   return (
-    <nav className="bg-white shadow-sm border-b border-gray-200">
+    <nav className="bg-white/80 backdrop-blur-md shadow-sm border-b border-gray-200 sticky top-0 z-20">
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           {/* Logo/Brand */}

--- a/src/index.css
+++ b/src/index.css
@@ -2,16 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@layer base {
+  body {
+    @apply font-sans bg-gray-50 text-gray-900 antialiased;
+  }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
-} 
+  code {
+    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+      monospace;
+  }
+}

--- a/src/pages/AddAlbumPage.tsx
+++ b/src/pages/AddAlbumPage.tsx
@@ -30,7 +30,7 @@ const AddAlbumPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-8">
         <header className="text-center mb-8">
           <h1 className="text-4xl font-bold text-gray-800 mb-2">Add Albums</h1>
@@ -46,7 +46,7 @@ const AddAlbumPage: React.FC = () => {
 
         <div className="max-w-2xl mx-auto">
           {/* Tab Navigation */}
-          <div className="bg-white rounded-lg shadow mb-6">
+          <div className="bg-white/80 backdrop-blur-md rounded-xl shadow mb-6">
             <div className="flex border-b border-gray-200">
               <button
                 onClick={() => setActiveTab('single')}

--- a/src/pages/CollectionPage.tsx
+++ b/src/pages/CollectionPage.tsx
@@ -49,7 +49,7 @@ const CollectionPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4 text-blue-600" />
           <div className="text-xl">Loading your vinyl collection...</div>
@@ -59,7 +59,7 @@ const CollectionPage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-8">
         <header className="text-center mb-8">
           <h1 className="text-4xl font-bold text-gray-800 mb-2">Your Collection</h1>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import { Disc, Plus, Upload, Music } from 'lucide-react';
 
 const HomePage: React.FC = () => {
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-16">
         <div className="text-center mb-16">
           <div className="flex justify-center mb-6">
@@ -20,7 +20,7 @@ const HomePage: React.FC = () => {
           {/* View Collection Card */}
           <Link
             to="/collection"
-            className="bg-white rounded-lg shadow-lg p-8 hover:shadow-xl transition-shadow group"
+            className="bg-white/80 backdrop-blur-md rounded-xl shadow-lg p-8 hover:shadow-xl transition-shadow group"
           >
             <div className="flex items-center justify-center w-16 h-16 bg-blue-100 rounded-full mb-6 mx-auto group-hover:bg-blue-200 transition-colors">
               <Music className="h-8 w-8 text-blue-600" />
@@ -34,7 +34,7 @@ const HomePage: React.FC = () => {
           {/* Add Albums Card */}
           <Link
             to="/add"
-            className="bg-white rounded-lg shadow-lg p-8 hover:shadow-xl transition-shadow group"
+            className="bg-white/80 backdrop-blur-md rounded-xl shadow-lg p-8 hover:shadow-xl transition-shadow group"
           >
             <div className="flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-6 mx-auto group-hover:bg-green-200 transition-colors">
               <Plus className="h-8 w-8 text-green-600" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,25 @@ module.exports = {
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: [
+          'SF Pro Text',
+          'SF Pro Display',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'Roboto',
+          'Oxygen',
+          'Ubuntu',
+          'Cantarell',
+          'Fira Sans',
+          'Droid Sans',
+          'Helvetica Neue',
+          'sans-serif',
+        ],
+      },
+    },
   },
   plugins: [],
 } 


### PR DESCRIPTION
## Summary
- apply SF Pro fonts via Tailwind config
- use frosted-glass backgrounds and softer gray for pages and components
- lighten the base styles

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests -w=0`

------
https://chatgpt.com/codex/tasks/task_e_6861d3c378f88325b4511da2c30b1911