### PR TITLE
Fix stats counts

### DIFF
--- a/src/hooks/useCatalogStats.ts
+++ b/src/hooks/useCatalogStats.ts
@@ -5,14 +5,20 @@ export const useCatalogStats = () =>
   useQuery({
     queryKey: ['catalogStats'],
     queryFn: async () => {
-      // Get all artists to aggregate top 5
-      const { data: allAlbums } = await supabase.from('albums').select('artist')
+      // Fetch minimal album data to compute stats client side
+      const { data: allAlbums = [] } = await supabase.from('albums').select('artist, release_year')
 
       // Aggregate top 5 artists in JS
       const artistCounts: Record<string, number> = {}
-      allAlbums?.forEach((a) => {
+      const decadeCounts: Record<string, number> = {}
+      allAlbums.forEach((a) => {
         artistCounts[a.artist] = (artistCounts[a.artist] || 0) + 1
+        if (a.release_year) {
+          const decade = Math.floor(a.release_year / 10) * 10
+          decadeCounts[decade] = (decadeCounts[decade] || 0) + 1
+        }
       })
+
       const topArtists = Object.entries(artistCounts)
         .sort((a, b) => b[1] - a[1])
         .slice(0, 5)
@@ -32,8 +38,17 @@ export const useCatalogStats = () =>
         .limit(1)
         .single()
 
-      const { data: totals } = await supabase.rpc('album_totals')
-      return { topArtists, oldest, newest, ...totals }
+      const total = allAlbums.length
+      const unique_artists = Object.keys(artistCounts).length
+
+      return {
+        topArtists,
+        oldest,
+        newest,
+        total,
+        unique_artists,
+        decade_counts: decadeCounts,
+      }
     },
     staleTime: 60_000,
   })

--- a/src/pages/StatsPage.test.tsx
+++ b/src/pages/StatsPage.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import StatsPage from './StatsPage'
+import { useCatalogStats } from '../hooks/useCatalogStats'
 
 jest.mock('../hooks/useCatalogStats')
-import { useCatalogStats } from '../hooks/useCatalogStats'
 
 const mockData = {
   topArtists: [
@@ -29,12 +29,21 @@ const mockData = {
   },
   total: 30,
   unique_artists: 12,
-  decade_counts: { '1950': 2, '1960': 3, '1970': 5, '1980': 7, '1990': 4, '2000': 3, '2010': 4, '2020': 2 },
+  decade_counts: {
+    '1950': 2,
+    '1960': 3,
+    '1970': 5,
+    '1980': 7,
+    '1990': 4,
+    '2000': 3,
+    '2010': 4,
+    '2020': 2,
+  },
 }
 
 describe('StatsPage', () => {
   beforeEach(() => {
-    (useCatalogStats as jest.Mock).mockReturnValue({
+    ;(useCatalogStats as jest.Mock).mockReturnValue({
       data: mockData,
       isLoading: false,
       error: null,


### PR DESCRIPTION
## Summary
- calculate collection totals client-side instead of via RPC
- reformat tests with prettier

## Testing
- `npm run lint --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6864ab27c3f08325b75fa2a73d5dff94